### PR TITLE
lock electron-builder version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "chai-as-promised": "^7.0.0",
     "del": "^3.0.0",
     "electron": "^1.6.2",
-    "electron-builder": "^18.6.2",
+    "electron-builder": "17.1.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-mocha": "^4.1.0",


### PR DESCRIPTION
lock electron-builder version(for win installer)
- because it can't show install message at other version.
